### PR TITLE
fix writesdpa.m sedumi form: A vs At

### DIFF
--- a/matlab/writesdpa.m
+++ b/matlab/writesdpa.m
@@ -3,10 +3,10 @@
 %
 %  Usage:
 %
-%  ret=writesdpa(fname,A,b,c,K,pars)
+%  ret=writesdpa(fname,At,b,c,K,pars)
 %
 %      fname           Name of SDPA file, in quotes
-%      A,b,c,K         Problem in SeDuMi form
+%      At,b,c,K        Problem in SeDuMi form
 %      pars            Optional parameters.
 %                      pars.printlevel=0           No printed output  
 %                      pars.printlevel=1 (default) Some printed output.
@@ -40,7 +40,7 @@
 %  First Version: 7/14/03.  Modified from old writesdp.m which wrote problems
 %                 in SDPPack format.
 %
-function ret=writesdpa(fname,A,b,c,K,pars)
+function ret=writesdpa(fname,At,b,c,K,pars)
 %
 % First, check to see whether or not we should be quiet.
 %
@@ -59,11 +59,11 @@ else
   quiet=0;
 end
 %
-%  First, check for complex numbers in A, b, or c.
+%  First, check for complex numbers in At, b, or c.
 %
-if (isreal(A) ~= 1)
+if (isreal(At) ~= 1)
   if (quiet == 0)
-    fprintf('A is not real!\n');
+    fprintf('At is not real!\n');
   end
   ret=1;
   return
@@ -123,17 +123,17 @@ end
 %
 m=length(b);
 %
-%  Deal with the following special case.  If A is transposed, transpose
-%  it again so that it is of the right size.
+%  Deal with the following special case.  If At is transposed (i.e., if it
+%  is just A), transpose it to obtain the actual At so that it is of 
+%  the right size.
 %
-[Am,An]=size(A);
+[An,Am]=size(At);
 if (Am ~= m)
   if (An == m)
     if (quiet==0)  
       fprintf('Transposing A to match b \n');
     end
-    AT=A;
-    A=A';
+    At=At';
 %
 % Also swap Am and An so that they're correct.
 %
@@ -150,11 +150,6 @@ if (Am ~= m)
     ret=1;
     return
   end
-else
-%
-% No need to transpose A, but we'll need AT.
-%
-  AT=A';
 end
 %
 %  Deal with the following special case:  if c==0, then c should really
@@ -334,7 +329,7 @@ for cn=1:m
 %  Print out the SDP part of constraint cn.
 %
   base=sizelin+1;
-  rowcn=AT(:,cn);
+  rowcn=At(:,cn);
   for i=1:nsdpblocks
     I=find(rowcn);
     II=find(I>=base);


### PR DESCRIPTION
Using [YALMIP](https://github.com/yalmip/YALMIP/tree/b2ff89d4924631552d41ae740c3f95a18088135d) , the following model is parsed correctly:

```matlab
y = sdpvar(4,1,'full');
A0 = [0 0; 0 0];
A1 = [1 0; 0 0]; A2 = [0 1; 1 0]; A3 = [0 0; 0 1]; A4 = -eye(2);
G = y(1)*A1 + y(2)*A2 + y(3)*A3 + y(4)*A4 - A0;
A = [y(1) y(2); y(2) y(3)];
F = [];
F = [F, G <= 0];
% F = [F, norm(A,2) <= 10];
optimize(F,y(4),sdpsettings('solver','csdp'))
```
But when the sedumi form is passed to `csdp.m` to write in spda form, it is parsed incorrectly, with `writespda.m` complaining about A being nonsymmetric:

```bash
Expanding c to the appropriate size
Number of constraints: 4 
Number of SDP blocks: 1 
Number of LP vars: 0 
Non symmetric A.s matrix! 
Non symmetric A.s matrix! 
Non symmetric A.s matrix! 
```

YALMIP is correctly passing `At,b,c,K` to `csdp.m`, which has the following function signature:

```matlab
%
% [x,y,z,info]=csdp(At,b,c,K,pars,x0,y0,z0)
%
% Uses CSDP to solve a problem in SeDuMi format.
```

However, it appears that `writespda.m` is not *actually* taking in sedumi (i.e., `A` vs `At`):

```matlab
%  This function takes a problem in SeDuMi MATLAB format and writes it out 
%  in SDPA sparse format.  
%
%  Usage:
%
%  ret=writesdpa(fname,A,b,c,K,pars)
%
%      fname           Name of SDPA file, in quotes
%      A,b,c,K         Problem in SeDuMi form
```

It seems that most of the time everything works correctly because of the [A vs At check in `writespda.m`](https://github.com/coin-or/Csdp/blob/master/matlab/writesdpa.m#L126); except for when A is square, like in the following sdpa file (corresponding to the model listed above):

```text
4 
1 
2 
0 0 0 1
1 1 1 1 -1
2 1 1 2 -1
3 1 2 2 -1
4 1 1 1  1
4 1 2 2  1
```

