### PR TITLE
Allows diagonal blocks to use the same array/pointer for both iindices and jidices

### DIFF
--- a/lib/freeprob.c
+++ b/lib/freeprob.c
@@ -50,7 +50,7 @@ void free_prob(n,k,C,a,constraints,X,y,Z)
 	  while (ptr != NULL)
 	    {
 	      free(ptr->entries);
-	      free(ptr->iindices);
+	      if (ptr->iindices != ptr->jindices) free(ptr->iindices);
 	      free(ptr->jindices);
 	      oldptr=ptr;
 	      ptr=ptr->next;


### PR DESCRIPTION
It allows having the iindices pointer to be equal to the jindices pointer in a diagonal block of the constraint matrices