### PR TITLE
Fix 2 functions calls with HIDDENSTRLEN

### DIFF
--- a/lib/linesearch.c
+++ b/lib/linesearch.c
@@ -175,7 +175,7 @@ double linesearch(n,dX,work1,work2,work3,cholinv,q,z,workvec,
       inc=1;
 
 #ifdef HIDDENSTRLEN
-      dgemv_("T",&n,&j,&scale1,lanczosvectors,&n,z+1,&inc,&scale2,reorth+1,&inc,1,1);
+      dgemv_("T",&n,&j,&scale1,lanczosvectors,&n,z+1,&inc,&scale2,reorth+1,&inc,1);
 #else
 #ifdef NOUNDERBLAS
 #ifdef CAPSBLAS

--- a/lib/sdp.c
+++ b/lib/sdp.c
@@ -771,6 +771,9 @@ int sdp(n,k,C,a,constant_offset,constraints,byblocks,fill,X,y,Z,cholxinv,
 	   t1=(double)tp.tv_sec+(1.0e-6)*tp.tv_usec;
 #endif
 
+#ifdef HIDDENSTRLEN
+	   dpotrf_("U",&m,O,&ldam,&info,1);
+#else
 #ifdef NOUNDERLAPACK
   #ifdef CAPSLAPACK
 	   DPOTRF("U",&m,O,&ldam,&info);
@@ -783,6 +786,7 @@ int sdp(n,k,C,a,constant_offset,constraints,byblocks,fill,X,y,Z,cholxinv,
   #else
 	   dpotrf_("U",&m,O,&ldam,&info);
   #endif
+#endif
 #endif
 
 #ifdef USEGETTIME


### PR DESCRIPTION
The Fedora project is in the process of rebuilding all packages with GCC 15, which defaults to the C23 standard.  One major change in C23 is that declarations of the form `type f();` no longer mean "a function that returns `type` with an unspecified parameter list".  Now such a declaration means "a function that returns `type` with an empty parameter list"; i.e., it is the same as `type f(void);`.  This has caused quite a few packages to fail to build, including the Csdp package.  While working with the sources to resolve this issue, one thing I did was to replace the BLAS and LAPACK function declarations at the bottom of `include/declarations.h` with the appropriate `#include` directives.  This turned up two cases where function calls failed to match the declarations.  We use a library where `HIDDENSTRLEN` needs to be defined (flexiblas).  This PR fixes both cases.
