### PR TITLE
Add proper declarations for BLAS/LAPACK functions

### DIFF
--- a/include/declarations.h
+++ b/include/declarations.h
@@ -237,53 +237,60 @@ int bisect_(int *n, double *eps1, double *d, double *e, double *e2,
 
 #ifdef CAPSBLAS
 #ifdef NOUNDERBLAS
-double DNRM2();
-double DASUM();
-double DDOT();
-int IDAMAX();
-void DGEMM();
-void DGEMV();
-void DGER();
-void DTRSM();
-void DTRMV();
-void DSYMV();
+#  define BLAS_FUNC(name, NAME) NAME
 #else
-double DNRM2_();
-double DASUM_();
-double DDOT_();
-int IDAMAX_();
-void DGEMM_();
-void DGEMV_();
-void DGER_();
-void DTRSM_();
-void DTRMV_();
-void DSYMV_();
+#  define BLAS_FUNC(name, NAME) NAME##_
 #endif
 #else
 #ifdef NOUNDERBLAS
-double dnrm2();
-double dasum();
-double ddot();
-int idamax();
-void dgemm();
-void dgemv();
-void dger();
-void dtrsm();
-void dtrmv();
-void dsymv();
+#  define BLAS_FUNC(name, NAME) name
 #else
-double dnrm2_();
-double dasum_();
-double ddot_();
-int idamax_();
-void dgemm_();
-void dgemv_();
-void dger_();
-void dtrsm_();
-void dtrmv_();
-void dsymv_();
+#  define BLAS_FUNC(name, NAME) name##_
 #endif
 #endif
+
+#ifdef HIDDENSTRLEN
+#include <stddef.h>
+#  define CSDP_STRLEN_DECL_1 , size_t
+#  define CSDP_STRLEN_DECL_2 , size_t, size_t
+#  define CSDP_STRLEN_DECL_3 , size_t, size_t, size_t
+#  define CSDP_STRLEN_1 , 1
+#  define CSDP_STRLEN_2 , 1, 1
+#  define CSDP_STRLEN_3 , 1, 1, 1
+#else
+#  define CSDP_STRLEN_DECL_1
+#  define CSDP_STRLEN_DECL_2
+#  define CSDP_STRLEN_DECL_3
+#  define CSDP_STRLEN_1
+#  define CSDP_STRLEN_2
+#  define CSDP_STRLEN_3
+#endif
+
+double BLAS_FUNC(dnrm2, DNRM2)(const int *n, const double *x, const int *incx);
+double BLAS_FUNC(dasum, DASUM)(const int *n, const double *x, const int *incx);
+double BLAS_FUNC(ddot, DDOT)(const int *n, const double *x, const int *incx,
+			     const double *y, const int *incy);
+int BLAS_FUNC(idamax, IDAMAX)(const int *n, const double *x, const int *incx);
+void BLAS_FUNC(dgemm, DGEMM)(const char *transa, const char *transb,
+			     const int *m, const int *n, const int *k,
+			     const double *alpha, const double *a,
+			     const int *lda, const double *b, const int *ldb,
+			     const double *beta, double *c, const int *ldc
+			     CSDP_STRLEN_DECL_2);
+void BLAS_FUNC(dgemv, DGEMV)(const char *trans, const int *m, const int *n,
+			     const double *alpha, const double *a,
+			     const int *lda, const double *x, const int *incx,
+			     const double *beta, double *y, const int *incy
+			     CSDP_STRLEN_DECL_1);
+void BLAS_FUNC(dsymv, DSYMV)(const char *uplo, const int *n,
+			     const double *alpha, const double *a,
+			     const int *lda, const double *x, const int *incx,
+			     const double *beta, double *y, const int *incy
+			     CSDP_STRLEN_DECL_1);
+void BLAS_FUNC(dtrmv, DTRMV)(const char *uplo, const char *trans,
+			     const char *diag, const int *n, const double *a,
+			     const int *lda, double *x, const int *incx
+			     CSDP_STRLEN_DECL_3);
 
 /*
   LAPACK next.
@@ -291,29 +298,39 @@ void dsymv_();
 
 #ifdef CAPSLAPACK
 #ifdef NOUNDERLAPACK
-void DPOTRF();
-void DPOTRS();
-void DPOTRI();
-void DTRTRI();
+#  define LAPACK_FUNC(name, NAME) NAME
 #else
-void DPOTRF_();
-void DPOTRS_();
-void DPOTRI_();
-void DTRTRI_();
+#  define LAPACK_FUNC(name, NAME) NAME##_
 #endif
 #else
 #ifdef NOUNDERLAPACK
-void dpotrf();
-void dpotrs();
-void dpotri();
-void dtrtri();
+#  define LAPACK_FUNC(name, NAME) name
 #else
-void dpotrf_();
-void dpotrs_();
-void dpotri_();
-void dtrtri_();
+#  define LAPACK_FUNC(name, NAME) name##_
 #endif
 #endif
 
+void LAPACK_FUNC(dpotrf, DPOTRF)(const char *uplo, const int *n,
+				 double *a, const int *lda, int *info
+				 CSDP_STRLEN_DECL_1);
+void LAPACK_FUNC(dpotrs, DPOTRS)(const char *uplo, const int *n,
+				 const int *nrhs, const double *a,
+				 const int *lda, double *b, const int *ldb,
+				 int *info CSDP_STRLEN_DECL_1);
+void LAPACK_FUNC(dtrtri, DTRTRI)(const char *uplo, const char *diag,
+				 const int *n, double *a, const int *lda,
+				 int *info CSDP_STRLEN_DECL_2);
+
+#define csdp_dnrm2(...) BLAS_FUNC(dnrm2, DNRM2)(__VA_ARGS__)
+#define csdp_dasum(...) BLAS_FUNC(dasum, DASUM)(__VA_ARGS__)
+#define csdp_ddot(...) BLAS_FUNC(ddot, DDOT)(__VA_ARGS__)
+#define csdp_idamax(...) BLAS_FUNC(idamax, IDAMAX)(__VA_ARGS__)
+#define csdp_dgemm(...) BLAS_FUNC(dgemm, DGEMM)(__VA_ARGS__ CSDP_STRLEN_2)
+#define csdp_dgemv(...) BLAS_FUNC(dgemv, DGEMV)(__VA_ARGS__ CSDP_STRLEN_1)
+#define csdp_dsymv(...) BLAS_FUNC(dsymv, DSYMV)(__VA_ARGS__ CSDP_STRLEN_1)
+#define csdp_dtrmv(...) BLAS_FUNC(dtrmv, DTRMV)(__VA_ARGS__ CSDP_STRLEN_3)
+#define csdp_dpotrf(...) LAPACK_FUNC(dpotrf, DPOTRF)(__VA_ARGS__ CSDP_STRLEN_1)
+#define csdp_dpotrs(...) LAPACK_FUNC(dpotrs, DPOTRS)(__VA_ARGS__ CSDP_STRLEN_1)
+#define csdp_dtrtri(...) LAPACK_FUNC(dtrtri, DTRTRI)(__VA_ARGS__ CSDP_STRLEN_2)
 
 #endif

--- a/lib/calc_dobj.c
+++ b/lib/calc_dobj.c
@@ -15,19 +15,7 @@ double calc_dobj(k,a,y,constant_offset)
 
   s=0.0;
 
-#ifdef NOUNDERBLAS
-#ifdef CAPSBLAS
-    s=s+DDOT(&k,a+1,&incx,y+1,&incx);
-#else
-    s=s+ddot(&k,a+1,&incx,y+1,&incx);
-#endif
-#else
-#ifdef CAPSBLAS
-    s=s+DDOT_(&k,a+1,&incx,y+1,&incx);
-#else
-    s=s+ddot_(&k,a+1,&incx,y+1,&incx);
-#endif
-#endif
+  s=s+csdp_ddot(&k,a+1,&incx,y+1,&incx);
 
   return(s+constant_offset);
   

--- a/lib/chol.c
+++ b/lib/chol.c
@@ -20,27 +20,7 @@ int chol_blk(n,lda,A)
 
   info=0;
 
-#ifdef HIDDENSTRLEN
-  dpotrf_("U",&n,A,&lda,&info,1);
-#else
-#ifdef HIDDENSTRLEN
-  dpotrf_("U",&n,A,&lda,&info,1);
-#else
-#ifdef NOUNDERLAPACK
-  #ifdef CAPSLAPACK
-    DPOTRF("U",&n,A,&lda,&info);
-  #else
-    dpotrf("U",&n,A,&lda,&info);
-  #endif
-#else
-  #ifdef CAPSLAPACK
-    DPOTRF_("U",&n,A,&lda,&info);
-  #else
-    dpotrf_("U",&n,A,&lda,&info);
-  #endif
-#endif
-#endif
-#endif
+  csdp_dpotrf("U",&n,A,&lda,&info);
     
   if (info != 0)
     {
@@ -182,23 +162,7 @@ void chol_inv(A,work)
 	  n=work.blocks[blk].blocksize;
 	  ap=work.blocks[blk].data.mat;
 
-#ifdef HIDDENSTRLEN
-   	  dtrtri_("U","N",&n,ap,&n,&info,1,1);
-#else
-#ifdef NOUNDERLAPACK
-#ifdef CAPSLAPACK
-	  DTRTRI("U","N",&n,ap,&n,&info);
-#else
-	  dtrtri("U","N",&n,ap,&n,&info);
-#endif
-#else
-#ifdef CAPSLAPACK
-	  DTRTRI_("U","N",&n,ap,&n,&info);
-#else
-	  dtrtri_("U","N",&n,ap,&n,&info);
-#endif
-#endif
-#endif
+	  csdp_dtrtri("U","N",&n,ap,&n,&info);
           
 	  if (info != 0)
 	    {

--- a/lib/linesearch.c
+++ b/lib/linesearch.c
@@ -174,88 +174,24 @@ double linesearch(n,dX,work1,work2,work3,cholinv,q,z,workvec,
       scale2=0.0;
       inc=1;
 
-#ifdef HIDDENSTRLEN
-      dgemv_("T",&n,&j,&scale1,lanczosvectors,&n,z+1,&inc,&scale2,reorth+1,&inc,1,1);
-#else
-#ifdef NOUNDERBLAS
-#ifdef CAPSBLAS
-      DGEMV("T",&n,&j,&scale1,lanczosvectors,&n,z+1,&inc,&scale2,reorth+1,&inc);
-#else
-      dgemv("T",&n,&j,&scale1,lanczosvectors,&n,z+1,&inc,&scale2,reorth+1,&inc);
-#endif
-#else
-#ifdef CAPSBLAS
-      DGEMV_("T",&n,&j,&scale1,lanczosvectors,&n,z+1,&inc,&scale2,reorth+1,&inc);
-#else
-      dgemv_("T",&n,&j,&scale1,lanczosvectors,&n,z+1,&inc,&scale2,reorth+1,&inc);
-#endif
-#endif
-#endif
+      csdp_dgemv("T",&n,&j,&scale1,lanczosvectors,&n,z+1,&inc,&scale2,reorth+1,&inc);
       scale1=-1.0;
       scale2=1.0;
       inc=1;
 
-#ifdef HIDDENSTRLEN
-      dgemv_("N",&n,&j,&scale1,lanczosvectors,&n,reorth+1,&inc,&scale2,z+1,&inc,1);
-#else
-#ifdef NOUNDERBLAS
-#ifdef CAPSBLAS
-      DGEMV("N",&n,&j,&scale1,lanczosvectors,&n,reorth+1,&inc,&scale2,z+1,&inc);
-#else
-      dgemv("N",&n,&j,&scale1,lanczosvectors,&n,reorth+1,&inc,&scale2,z+1,&inc);
-#endif
-#else
-#ifdef CAPSBLAS
-      DGEMV_("N",&n,&j,&scale1,lanczosvectors,&n,reorth+1,&inc,&scale2,z+1,&inc);
-#else
-      dgemv_("N",&n,&j,&scale1,lanczosvectors,&n,reorth+1,&inc,&scale2,z+1,&inc);
-#endif
-#endif
-#endif
+      csdp_dgemv("N",&n,&j,&scale1,lanczosvectors,&n,reorth+1,&inc,&scale2,z+1,&inc);
 	  
       scale1=1.0;
       scale2=0.0;
       inc=1;
 
-#ifdef HIDDENSTRLEN
-      dgemv_("T",&n,&j,&scale1,lanczosvectors,&n,z+1,&inc,&scale2,reorth+1,&inc,1);
-#else
-#ifdef NOUNDERBLAS
-#ifdef CAPSBLAS
-      DGEMV("T",&n,&j,&scale1,lanczosvectors,&n,z+1,&inc,&scale2,reorth+1,&inc);
-#else
-      dgemv("T",&n,&j,&scale1,lanczosvectors,&n,z+1,&inc,&scale2,reorth+1,&inc);
-#endif
-#else
-#ifdef CAPSBLAS
-      DGEMV_("T",&n,&j,&scale1,lanczosvectors,&n,z+1,&inc,&scale2,reorth+1,&inc);
-#else
-      dgemv_("T",&n,&j,&scale1,lanczosvectors,&n,z+1,&inc,&scale2,reorth+1,&inc);
-#endif
-#endif
-#endif
+      csdp_dgemv("T",&n,&j,&scale1,lanczosvectors,&n,z+1,&inc,&scale2,reorth+1,&inc);
 
       scale1=-1.0;
       scale2=1.0;
       inc=1;
 
-#ifdef HIDDENSTRLEN
-      dgemv_("N",&n,&j,&scale1,lanczosvectors,&n,reorth+1,&inc,&scale2,z+1,&inc,1);     
-#else
-#ifdef NOUNDERBLAS
-#ifdef CAPSBLAS
-      DGEMV("N",&n,&j,&scale1,lanczosvectors,&n,reorth+1,&inc,&scale2,z+1,&inc);
-#else
-      dgemv("N",&n,&j,&scale1,lanczosvectors,&n,reorth+1,&inc,&scale2,z+1,&inc);
-#endif
-#else
-#ifdef CAPSBLAS
-      DGEMV_("N",&n,&j,&scale1,lanczosvectors,&n,reorth+1,&inc,&scale2,z+1,&inc);
-#else
-      dgemv_("N",&n,&j,&scale1,lanczosvectors,&n,reorth+1,&inc,&scale2,z+1,&inc);
-#endif
-#endif
-#endif	  
+      csdp_dgemv("N",&n,&j,&scale1,lanczosvectors,&n,reorth+1,&inc,&scale2,z+1,&inc);
 
       /*
        * Compute the norm of z.

--- a/lib/mat_mult.c
+++ b/lib/mat_mult.c
@@ -96,23 +96,7 @@ void mat_mult_raw(n,scale1,scale2,ap,bp,cp)
      double *cp;
 {
 
-#ifdef HIDDENSTRLEN
-  dgemm_("N","N",&n,&n,&n,&scale1,ap,&n,bp,&n,&scale2,cp,&n,1,1);
-#else
-#ifdef NOUNDERBLAS
-#ifdef CAPSBLAS
-	  DGEMM("N","N",&n,&n,&n,&scale1,ap,&n,bp,&n,&scale2,cp,&n);
-#else
-	  dgemm("N","N",&n,&n,&n,&scale1,ap,&n,bp,&n,&scale2,cp,&n);
-#endif
-#else
-#ifdef CAPSBLAS
-	  DGEMM_("N","N",&n,&n,&n,&scale1,ap,&n,bp,&n,&scale2,cp,&n);
-#else
-	  dgemm_("N","N",&n,&n,&n,&scale1,ap,&n,bp,&n,&scale2,cp,&n);
-#endif
-#endif
-#endif
+  csdp_dgemm("N","N",&n,&n,&n,&scale1,ap,&n,bp,&n,&scale2,cp,&n);
 }
 
 #ifdef USEATLAS

--- a/lib/matvec.c
+++ b/lib/matvec.c
@@ -49,23 +49,7 @@ void matvec(A,x,y)
 	  scale1=1.0;
 	  scale2=0.0;
 
-#ifdef HIDDENSTRLEN
-	  dgemv_("N",&n,&n,&scale1,ap,&n,x+p,&inc,&scale2,y+p,&inc,1);
-#else
-#ifdef NOUNDERBLAS
-#ifdef CAPSBLAS
-	  DGEMV("N",&n,&n,&scale1,ap,&n,x+p,&inc,&scale2,y+p,&inc);
-#else
-	  dgemv("N",&n,&n,&scale1,ap,&n,x+p,&inc,&scale2,y+p,&inc);
-#endif
-#else
-#ifdef CAPSBLAS
-	  DGEMV_("N",&n,&n,&scale1,ap,&n,x+p,&inc,&scale2,y+p,&inc);
-#else
-	  dgemv_("N",&n,&n,&scale1,ap,&n,x+p,&inc,&scale2,y+p,&inc);
-#endif
-#endif
-#endif
+	  csdp_dgemv("N",&n,&n,&scale1,ap,&n,x+p,&inc,&scale2,y+p,&inc);
 	  
 	  p=p+n;
 
@@ -125,23 +109,7 @@ void matvecsym(A,x,y)
 	  scale1=1.0;
 	  scale2=0.0;
 
-#ifdef HIDDENSTRLEN
-	  dsymv_("U",&n,&scale1,ap,&n,x+p,&inc,&scale2,y+p,&inc,1);
-#else
-#ifdef NOUNDERBLAS
-#ifdef CAPSBLAS
-	  DSYMV("U",&n,&scale1,ap,&n,x+p,&inc,&scale2,y+p,&inc);	  
-#else
-  	  dsymv("U",&n,&scale1,ap,&n,x+p,&inc,&scale2,y+p,&inc);	  
-#endif
-#else
-#ifdef CAPSBLAS
-  	  DSYMV_("U",&n,&scale1,ap,&n,x+p,&inc,&scale2,y+p,&inc);
-#else
-  	  dsymv_("U",&n,&scale1,ap,&n,x+p,&inc,&scale2,y+p,&inc);
-#endif
-#endif
-#endif
+	  csdp_dsymv("U",&n,&scale1,ap,&n,x+p,&inc,&scale2,y+p,&inc);
 	  
 	  p=p+n;
 
@@ -207,23 +175,7 @@ void matvecR(A,x,y)
 	  ap=A.blocks[blk].data.mat;
           inc=1;
 
-#ifdef HIDDENSTRLEN
-          dtrmv_("U","N","N",&n,ap,&n,y+p,&inc,1,1,1);
-#else
-#ifdef NOUNDERBLAS
-#ifdef CAPSBLAS
-          DTRMV("U","N","N",&n,ap,&n,y+p,&inc);
-#else
-          dtrmv("U","N","N",&n,ap,&n,y+p,&inc);
-#endif
-#else
-#ifdef CAPSBLAS
-          DTRMV_("U","N","N",&n,ap,&n,y+p,&inc);
-#else
-  	  dtrmv_("U","N","N",&n,ap,&n,y+p,&inc);
-#endif
-#endif
-#endif
+	  csdp_dtrmv("U","N","N",&n,ap,&n,y+p,&inc);
 	  
 	  p=p+n;
 
@@ -288,23 +240,7 @@ void matvecRT(A,x,y)
 	  ap=A.blocks[blk].data.mat;
           inc=1;
 
-#ifdef HIDDENSTRLEN
-          dtrmv_("U","T","N",&n,ap,&n,y+p,&inc,1,1,1);
-#else
-#ifdef NOUNDERBLAS
-#ifdef CAPSBLAS
-          DTRMV("U","T","N",&n,ap,&n,y+p,&inc);
-#else
-          dtrmv("U","T","N",&n,ap,&n,y+p,&inc);
-#endif
-#else
-#ifdef CAPSBLAS
-          DTRMV_("U","T","N",&n,ap,&n,y+p,&inc);
-#else
-  	  dtrmv_("U","T","N",&n,ap,&n,y+p,&inc);
-#endif
-#endif
-#endif
+	  csdp_dtrmv("U","T","N",&n,ap,&n,y+p,&inc);
 	  
 	  p=p+n;
 

--- a/lib/norms.c
+++ b/lib/norms.c
@@ -12,19 +12,7 @@ double norm2(n,x)
   double nrm;
   int incx=1;
 
-#ifdef NOUNDERBLAS
-#ifdef CAPSBLAS
-  nrm=DNRM2(&n,x,&incx);
-#else
-  nrm=dnrm2(&n,x,&incx);
-#endif
-#else
-#ifdef CAPSBLAS
-  nrm=DNRM2_(&n,x,&incx);
-#else
-  nrm=dnrm2_(&n,x,&incx);
-#endif
-#endif
+  nrm=csdp_dnrm2(&n,x,&incx);
   
   return(nrm);
 }
@@ -36,19 +24,7 @@ double norm1(n,x)
   double nrm;
   int incx=1;
 
-#ifdef NOUNDERBLAS
-#ifdef CAPSBLAS
-  nrm=DASUM(&n,x,&incx);
-#else
-  nrm=dasum(&n,x,&incx);
-#endif
-#else
-#ifdef CAPSBLAS
-  nrm=DASUM_(&n,x,&incx);
-#else
-  nrm=dasum_(&n,x,&incx);
-#endif
-#endif
+  nrm=csdp_dasum(&n,x,&incx);
   
   return(nrm);
 }
@@ -61,24 +37,8 @@ double norminf(n,x)
   double nrm;
   int incx=1;
 
-#ifdef NOUNDERBLAS
-#ifdef CAPSBLAS
-  i=IDAMAX(&n,x,&incx);
-  nrm=fabs(x[i-1]);
-#else
-  i=idamax(&n,x,&incx);
-  nrm=fabs(x[i-1]);
-#endif
-#else
-#ifdef CAPSBLAS
-  i=IDAMAX_(&n,x,&incx);
-  nrm=fabs(x[i-1]);
-#else
-  i=idamax_(&n,x,&incx);
-  nrm=fabs(x[i-1]);
-#endif
-#endif
-  
+  i=csdp_idamax(&n,x,&incx);
+
   return(nrm);
 }
 

--- a/lib/sdp.c
+++ b/lib/sdp.c
@@ -771,19 +771,7 @@ int sdp(n,k,C,a,constant_offset,constraints,byblocks,fill,X,y,Z,cholxinv,
 	   t1=(double)tp.tv_sec+(1.0e-6)*tp.tv_usec;
 #endif
 
-#ifdef NOUNDERLAPACK
-  #ifdef CAPSLAPACK
-	   DPOTRF("U",&m,O,&ldam,&info);
-  #else
-	   dpotrf("U",&m,O,&ldam,&info);
-  #endif
-#else
-  #ifdef CAPSLAPACK
-	   DPOTRF_("U",&m,O,&ldam,&info);
-  #else
-	   dpotrf_("U",&m,O,&ldam,&info);
-  #endif
-#endif
+	   csdp_dpotrf("U",&m,O,&ldam,&info);
 
 #ifdef USEGETTIME
 	   gettimeofday(&tp,NULL);

--- a/lib/solvesys.c
+++ b/lib/solvesys.c
@@ -19,23 +19,7 @@ int solvesys(m,ldam,A,rhs)
 
   incx=1;
 
-#ifdef HIDDENSTRLEN
-  dpotrs_("U",&m,&incx,A,&ldam,rhs+1,&ldam,&info,1);
-#else
-#ifdef NOUNDERLAPACK
-  #ifdef CAPSLAPACK
-	   DPOTRS("U",&m,&incx,A,&ldam,rhs+1,&ldam,&info);
-  #else
-	   dpotrs("U",&m,&incx,A,&ldam,rhs+1,&ldam,&info);
-  #endif
-#else
-  #ifdef CAPSLAPACK	
-	   DPOTRS_("U",&m,&incx,A,&ldam,rhs+1,&ldam,&info);
-  #else
-	   dpotrs_("U",&m,&incx,A,&ldam,rhs+1,&ldam,&info);
-  #endif
-#endif
-#endif
+  csdp_dpotrs("U",&m,&incx,A,&ldam,rhs+1,&ldam,&info);
 
 	   if (info != 0)
 	     {


### PR DESCRIPTION
Otherwise, when compiling with C23 (which is the default in GCC 15), we get "too many arguments to function" errors.

We also add BLAS_FUNC and LAPACK_FUNC macros so we don't need to have four different declarations for each function.